### PR TITLE
Added BlockTrampleEvent

### DIFF
--- a/src/main/java/myessentials/DepLoader.java
+++ b/src/main/java/myessentials/DepLoader.java
@@ -12,6 +12,7 @@ import java.util.Map;
  * For autodownloading stuff.
  * This is really unoriginal, mostly ripped off FML, credits to cpw and chicken-bones.
  */
+@IFMLLoadingPlugin.SortingIndex(1001)
 public class DepLoader implements IFMLLoadingPlugin, IFMLCallHook {
     @Override
     public Void call() throws Exception {
@@ -24,7 +25,9 @@ public class DepLoader implements IFMLLoadingPlugin, IFMLCallHook {
 
     @Override
     public String[] getASMTransformerClass() {
-        return null;
+        return new String[]{
+                "myessentials.classtransformers.BlockFarmlandTransformer"
+        };
     }
 
     @Override

--- a/src/main/java/myessentials/classtransformers/BlockFarmlandTransformer.java
+++ b/src/main/java/myessentials/classtransformers/BlockFarmlandTransformer.java
@@ -1,0 +1,95 @@
+package myessentials.classtransformers;
+
+import net.minecraft.launchwrapper.IClassTransformer;
+import org.objectweb.asm.*;
+import org.objectweb.asm.commons.GeneratorAdapter;
+
+/**
+ * Patches BlockFarmland to add a hook for the {@link myessentials.event.BlockTrampleEvent}.
+ * <br/>
+ * The final code would be:
+ * <pre><code>
+ *     public class BlockFarmland extends Block{
+ *         // ... original fields and methods
+ *
+ *         public void onFallenUpon(World world, int x, int y, int z, Entity entity, float p6){
+ *             // ... original code
+ *             if(BlockTrampleEvent.fireEvent(entity, this, x, y, z))
+ *               return;
+ *             // ... original code
+ *         }
+ *
+ *         // ... original methods
+ *     }
+ * </code></pre>
+ */
+public class BlockFarmlandTransformer implements IClassTransformer {
+
+    /**
+     * Generates code before the first ALOAD 1 that comes after the first RETURN.<br>
+     * The code that is generated is:
+     * <pre><code>if(BlockTrampleEvent.fireEvent(entity, this, x, y, z)) return;</code></pre>
+     */
+    private class FarmlandGeneratorAdapter extends GeneratorAdapter {
+        boolean patched = false;
+        boolean waitingALoad1 = false;
+
+        protected FarmlandGeneratorAdapter(MethodVisitor mv, int access, String name, String desc) {
+            super(Opcodes.ASM4, mv, access, name, desc);
+        }
+
+        @Override
+        public void visitInsn(int opcode) {
+            super.visitInsn(opcode);
+            if(!patched && opcode == Opcodes.RETURN) {
+                waitingALoad1 = true;
+            }
+        }
+
+        @Override
+        public void visitVarInsn(int opcode, int var) {
+            if(!patched && waitingALoad1 && opcode == Opcodes.ALOAD && var == 1) {
+                super.visitVarInsn(Opcodes.ALOAD, 5);
+                super.visitVarInsn(Opcodes.ALOAD, 0);
+                super.visitVarInsn(Opcodes.ILOAD, 2);
+                super.visitVarInsn(Opcodes.ILOAD, 3);
+                super.visitVarInsn(Opcodes.ILOAD, 4);
+                super.visitMethodInsn(Opcodes.INVOKESTATIC, "myessentials/event/BlockTrampleEvent", "fireEvent", "(Lnet/minecraft/entity/Entity;Lnet/minecraft/block/BlockFarmland;III)Z", false);
+
+                Label elseLabel = new Label();
+                super.visitJumpInsn(Opcodes.IFEQ, elseLabel);
+                super.visitInsn(Opcodes.RETURN);
+                super.visitLabel(elseLabel);
+                patched = true;
+            }
+
+            super.visitVarInsn(opcode, var);
+        }
+    }
+
+    @Override
+    public byte[] transform(String name, String srgName, byte[] bytes) {
+        if("net.minecraft.block.BlockFarmland".equals(srgName)) {
+            ClassReader reader = new ClassReader(bytes);
+            ClassWriter writer = new ClassWriter(reader, Opcodes.ASM4);
+
+            ClassVisitor visitor = new ClassVisitor(Opcodes.ASM4, writer) {
+                @Override
+                public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+                    MethodVisitor methodVisitor = super.visitMethod(access, name, desc, signature, exceptions);
+
+                    if("func_149746_a".equals(name) || "onFallenUpon".equals(name))
+                        return new FarmlandGeneratorAdapter(methodVisitor, access, name, desc);
+
+                    return methodVisitor;
+                }
+            };
+
+            reader.accept(visitor, ClassReader.EXPAND_FRAMES);
+
+            bytes = writer.toByteArray();
+        }
+
+        return bytes;
+    }
+}

--- a/src/main/java/myessentials/event/BlockTrampleEvent.java
+++ b/src/main/java/myessentials/event/BlockTrampleEvent.java
@@ -1,0 +1,20 @@
+package myessentials.event;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockFarmland;
+import net.minecraft.entity.Entity;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.world.BlockEvent;
+
+public class BlockTrampleEvent extends BlockEvent {
+    public final Entity entity;
+
+    public BlockTrampleEvent(Entity entity, int x, int y, int z, Block block, int blockMetadata) {
+        super(x, y, z, entity.worldObj, block, blockMetadata);
+        this.entity = entity;
+    }
+
+    public static boolean fireEvent(Entity entity, BlockFarmland block, int x, int y, int z) {
+        return MinecraftForge.EVENT_BUS.post(new BlockTrampleEvent(entity, x, y, z, block, entity.worldObj.getBlockMetadata(x, y, z)));
+    }
+}

--- a/src/main/java/myessentials/event/BlockTrampleEvent.java
+++ b/src/main/java/myessentials/event/BlockTrampleEvent.java
@@ -1,12 +1,20 @@
 package myessentials.event;
 
+import cpw.mods.fml.common.eventhandler.Cancelable;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockFarmland;
 import net.minecraft.entity.Entity;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.world.BlockEvent;
 
+/**
+ * Fired when an entity tramples a farmland
+ */
+@Cancelable
 public class BlockTrampleEvent extends BlockEvent {
+    /**
+     * The entity that trampled the farm land
+     */
     public final Entity entity;
 
     public BlockTrampleEvent(Entity entity, int x, int y, int z, Block block, int blockMetadata) {
@@ -14,6 +22,7 @@ public class BlockTrampleEvent extends BlockEvent {
         this.entity = entity;
     }
 
+    @SuppressWarnings("unused")
     public static boolean fireEvent(Entity entity, BlockFarmland block, int x, int y, int z) {
         return MinecraftForge.EVENT_BUS.post(new BlockTrampleEvent(entity, x, y, z, block, entity.worldObj.getBlockMetadata(x, y, z)));
     }


### PR DESCRIPTION
This event is needed to fix https://github.com/MyEssentials/MyTown2/issues/139 that allow players and tamed entities to trample crops on protected locations.

I'll also try to submit a pull request to Minecraft Forge with a similar event, but they 83 open pull requests and I think it'll take a while until they add it to the mod (if they accept the pull request...) until there we can easily use our own event and do the necessary changes when it get implemented on forge.