### PR TITLE
Reworked signs to store data on NBT tags

### DIFF
--- a/src/main/java/myessentials/DepLoader.java
+++ b/src/main/java/myessentials/DepLoader.java
@@ -3,6 +3,7 @@ package myessentials;
 import cpw.mods.fml.relauncher.FMLInjectionData;
 import cpw.mods.fml.relauncher.IFMLCallHook;
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
+import myessentials.entities.sign.SignClassTransformer;
 import net.minecraft.launchwrapper.LaunchClassLoader;
 
 import java.io.File;
@@ -12,6 +13,7 @@ import java.util.Map;
  * For autodownloading stuff.
  * This is really unoriginal, mostly ripped off FML, credits to cpw and chicken-bones.
  */
+@IFMLLoadingPlugin.SortingIndex(1001)
 public class DepLoader implements IFMLLoadingPlugin, IFMLCallHook {
     @Override
     public Void call() throws Exception {
@@ -24,7 +26,9 @@ public class DepLoader implements IFMLLoadingPlugin, IFMLCallHook {
 
     @Override
     public String[] getASMTransformerClass() {
-        return null;
+        return new String[]{
+                SignClassTransformer.class.getName()
+        };
     }
 
     @Override

--- a/src/main/java/myessentials/DepLoader.java
+++ b/src/main/java/myessentials/DepLoader.java
@@ -3,7 +3,6 @@ package myessentials;
 import cpw.mods.fml.relauncher.FMLInjectionData;
 import cpw.mods.fml.relauncher.IFMLCallHook;
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
-import myessentials.entities.sign.SignClassTransformer;
 import net.minecraft.launchwrapper.LaunchClassLoader;
 
 import java.io.File;
@@ -27,7 +26,7 @@ public class DepLoader implements IFMLLoadingPlugin, IFMLCallHook {
     @Override
     public String[] getASMTransformerClass() {
         return new String[]{
-                SignClassTransformer.class.getName()
+                "myessentials.classtransformers.SignClassTransformer"
         };
     }
 

--- a/src/main/java/myessentials/classtransformers/SignClassTransformer.java
+++ b/src/main/java/myessentials/classtransformers/SignClassTransformer.java
@@ -1,4 +1,4 @@
-package myessentials.entities.sign;
+package myessentials.classtransformers;
 
 import net.minecraft.launchwrapper.IClassTransformer;
 import net.minecraft.nbt.NBTTagCompound;
@@ -151,7 +151,7 @@ public class SignClassTransformer implements IClassTransformer {
         public void visitInsn(int opcode) {
             // If the current instruction is return
             if(opcode == Opcodes.RETURN) {
-                // Add: myessentials.entities.sign.SignClassTransformer.<localMethodName>(this, arg1);
+                // Add: myessentials.classtransformers.SignClassTransformer.<localMethodName>(this, arg1);
                 // before the return statement
                 super.visitVarInsn(Opcodes.ALOAD, 0);
                 super.visitVarInsn(Opcodes.ALOAD, 1);

--- a/src/main/java/myessentials/entities/sign/Sign.java
+++ b/src/main/java/myessentials/entities/sign/Sign.java
@@ -1,9 +1,10 @@
 package myessentials.entities.sign;
 
-import myessentials.MyEssentialsCore;
 import myessentials.entities.BlockPos;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntitySign;
@@ -23,7 +24,15 @@ public abstract class Sign {
 
     public static final String IDENTIFIER = EnumChatFormatting.DARK_BLUE.toString();
 
+    public final SignType signType;
+
+    protected NBTBase data;
+
     protected BlockPos bp;
+
+    protected Sign(SignType signType) {
+        this.signType = signType;
+    }
 
     public abstract void onRightClick(EntityPlayer player);
 
@@ -51,6 +60,12 @@ public abstract class Sign {
             te.signText[i] = text[i] == null ? "" : text[i];
         }
 
+        NBTTagCompound rootTag = new NBTTagCompound();
+        rootTag.setString("Type", signType.getTypeID());
+        if(data != null)
+            rootTag.setTag("Value", data);
+        SignClassTransformer.setMyEssentialsDataValue(te, rootTag);
+
         return te;
     }
 
@@ -72,7 +87,6 @@ public abstract class Sign {
         World world = MinecraftServer.getServer().worldServerForDimension(bp.getDim());
         world.removeTileEntity(bp.getX(), bp.getY(), bp.getZ());
         world.setBlock(bp.getX(), bp.getY(), bp.getZ(), Blocks.air);
-        SignManager.instance.signs.remove(this);
     }
 
     public static class Container extends ArrayList<Sign> {

--- a/src/main/java/myessentials/entities/sign/Sign.java
+++ b/src/main/java/myessentials/entities/sign/Sign.java
@@ -1,5 +1,6 @@
 package myessentials.entities.sign;
 
+import myessentials.classtransformers.SignClassTransformer;
 import myessentials.entities.BlockPos;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;

--- a/src/main/java/myessentials/entities/sign/SignClassTransformer.java
+++ b/src/main/java/myessentials/entities/sign/SignClassTransformer.java
@@ -1,0 +1,223 @@
+package myessentials.entities.sign;
+
+import net.minecraft.launchwrapper.IClassTransformer;
+import net.minecraft.nbt.NBTTagCompound;
+import org.objectweb.asm.*;
+import org.objectweb.asm.commons.GeneratorAdapter;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Field;
+
+/**
+ * Do a simple modification on {@link net.minecraft.tileentity.TileEntitySign} to add a custom field and two static invocations.
+ * <br/>
+ * The final code would be:
+ * <pre><code>
+ *     public class TileEntitySign extends TileEntity{
+ *         public NBTTagCompound myEssentials;
+ *         // ... original fields
+ *
+ *         public void writeToNBT(NBTTagCompound var1){
+ *             // ... original code
+ *             SignClassTransformer.writeToNBT(this, var1);
+ *         }
+ *
+ *         public void readFromNBT(NBTTagCompound var1){
+ *             // ... original code
+ *             SignClassTransformer.readFromNBT(this, var1);
+ *         }
+ *     }
+ * </code></pre>
+ * <p>
+ *     This class also allows reading and writing the custom field.
+ * </p>
+ */
+public class SignClassTransformer implements IClassTransformer {
+    /**
+     * The key that will be used to store all the sign data on a {@link NBTTagCompound}
+     */
+    public static final String TAG_ROOT = "MyEssentials";
+    /**
+     * The field name that will be added to the {@link net.minecraft.tileentity.TileEntitySign}
+     */
+    public static final String FIELD_NAME = "myEssentials";
+
+    // ------- MOD PART ------- //
+    // This part provide read/write access to the custom field in-game.
+
+    /**
+     * The cached field. We cache it to increase performance.
+     */
+    private static Field myEssentialsDataField;
+
+    /**
+     * Get the cached field or initialize it if it's not initialized yet
+     * @param sign A instance of {@link net.minecraft.tileentity.TileEntitySign}. It's an {@link Object} arg to simplify the ASM code generation.
+     * @return The cached field
+     * @throws RuntimeException if the transformer failed
+     */
+    private static Field getMyEssentialsDataField(Object sign) {
+        if(myEssentialsDataField == null)
+            try {
+                myEssentialsDataField = sign.getClass().getField(FIELD_NAME);
+            }
+            catch (NoSuchFieldException e) {
+                throw new RuntimeException(e);
+            }
+
+        return myEssentialsDataField;
+    }
+
+    /**
+     * Read the custom field stored in a patched {@link net.minecraft.tileentity.TileEntitySign}.
+     * @param sign A instance of {@link net.minecraft.tileentity.TileEntitySign}. It's an {@link Object} arg to simplify the ASM code generation.
+     * @return The custom data.
+     */
+    @Nullable
+    public static NBTTagCompound getMyEssentialsDataValue(Object sign) {
+        try {
+            return (NBTTagCompound) getMyEssentialsDataField(sign).get(sign);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Store the data to the custom field.
+     * @param sign A instance of {@link net.minecraft.tileentity.TileEntitySign}. It's an {@link Object} arg to simplify the ASM code generation.
+     * @param modData The custom data.
+     */
+    public static void setMyEssentialsDataValue(Object sign, @Nullable NBTTagCompound modData) {
+        try {
+            getMyEssentialsDataField(sign).set(sign, modData);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // ------- CORE-MOD PART ------- //
+    // This part patches the TileEntitySign to add the custom field provide save/load support
+
+    /**
+     * Method executed before {@link net.minecraft.tileentity.TileEntitySign#writeToNBT(NBTTagCompound)} returns
+     * @param sign A instance of {@link net.minecraft.tileentity.TileEntitySign}. It's an {@link Object} arg to simplify the ASM code generation.
+     * @param tagCompound The NBT tag that is being written
+     */
+    @SuppressWarnings("unused")
+    public static void writeToNBT(Object sign, NBTTagCompound tagCompound) {
+        NBTTagCompound modData = getMyEssentialsDataValue(sign);
+        if(modData != null)
+            tagCompound.setTag(TAG_ROOT, modData);
+    }
+
+    /**
+     * Method executed before {@link net.minecraft.tileentity.TileEntitySign#writeToNBT(NBTTagCompound)} returns
+     * @param sign A instance of {@link net.minecraft.tileentity.TileEntitySign}. It's an {@link Object} arg to simplify the ASM code generation.
+     * @param tagCompound The NBT tag that is being read
+     */
+    @SuppressWarnings("unused")
+    public static void readFromNBT(Object sign, NBTTagCompound tagCompound) {
+        NBTTagCompound modData = (NBTTagCompound) tagCompound.getTag(TAG_ROOT);
+        setMyEssentialsDataValue(sign, modData);
+    }
+
+    /**
+     * Adds an static invocation to a method on this class, the local method must return {@code void} and accept the arguments {@link Object} and {@link NBTTagCompound}
+     */
+    private class SignGeneratorAdapter extends GeneratorAdapter {
+        /**
+         * The name of a method in {@link SignClassTransformer}.
+         */
+        String localMethodName;
+
+        /**
+         * Constructor that preserves the method name and properties attributes
+         * @param mv The method that is being visited
+         * @param access The method access flag
+         * @param name The method name
+         * @param desc The method description (arguments and return type)
+         * @param localMethodName The static method on {@link SignClassTransformer} that will be executed before the visited method returns
+         */
+        SignGeneratorAdapter(MethodVisitor mv, int access, String name, String desc, String localMethodName) {
+            super(Opcodes.ASM4, mv, access, name, desc);
+            this.localMethodName = localMethodName;
+        }
+
+        /**
+         * Visit all instructions and add an static invocation before the method returns
+         * @param opcode The current instruction
+         */
+        @Override
+        public void visitInsn(int opcode) {
+            // If the current instruction is return
+            if(opcode == Opcodes.RETURN) {
+                // Add: myessentials.entities.sign.SignClassTransformer.<localMethodName>(this, arg1);
+                // before the return statement
+                super.visitVarInsn(Opcodes.ALOAD, 0);
+                super.visitVarInsn(Opcodes.ALOAD, 1);
+                super.visitMethodInsn(Opcodes.INVOKESTATIC,
+                        "myessentials/entities/sign/SignClassTransformer", localMethodName, "(Ljava/lang/Object;Lnet/minecraft/nbt/NBTTagCompound;)V", false);
+            }
+
+            // Add the current instruction
+            super.visitInsn(opcode);
+        }
+    }
+
+    /**
+     * Patches the {@link net.minecraft.tileentity.TileEntitySign}
+     * @param name Obfuscated name of the class that is being loaded
+     * @param srgName SRG name of the class that is being loaded
+     * @param bytes Class that is being loaded
+     * @return The modified class
+     */
+    @Override
+    public byte[] transform(String name, String srgName, byte[] bytes) {
+        // We will modify only the Sign class
+        if("net.minecraft.tileentity.TileEntitySign".equals(srgName)) {
+            // Initialize ASM
+            ClassReader reader = new ClassReader(bytes);
+            ClassWriter writer = new ClassWriter(reader, Opcodes.ASM4);
+
+            // Add the custom field to the class
+            writer.visitField(Opcodes.ACC_PUBLIC, FIELD_NAME, "Lnet/minecraft/nbt/NBTTagCompound;", null, null).visitEnd();
+
+            // This will iterate over everything on the class and allow us to modify what we want
+            ClassVisitor visitor = new ClassVisitor(Opcodes.ASM4, writer) {
+                /**
+                 * Modify the writeToNBT and readFromNBT methods to save/load our custom data
+                 * @param access The current method's access flag
+                 * @param name The current method's name
+                 * @param desc The current method's description (arguments and return type)
+                 * @param signature The current method's signature
+                 * @param exceptions The exceptions that can be thrown by the current method
+                 * @return The modified method
+                 */
+                @Override
+                public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+                    // Load the method
+                    MethodVisitor methodVisitor = super.visitMethod(access, name, desc, signature, exceptions);
+
+                    // The SRG name will be on obfuscated environment
+                    if("func_145841_b".equals(name) || "writeToNBT".equals(name))
+                        return new SignGeneratorAdapter(methodVisitor, access, name, desc, "writeToNBT");
+
+                    else if("func_145839_a".equals(name) || "readFromNBT".equals(name))
+                        return new SignGeneratorAdapter(methodVisitor, access, name, desc, "readFromNBT");
+
+                    // Return the unmodified method
+                    return methodVisitor;
+                }
+            };
+
+            // Update the reader with our modification
+            reader.accept(visitor, ClassReader.EXPAND_FRAMES);
+
+            // Save and return the modified class
+            bytes = writer.toByteArray();
+        }
+
+        // If it was the sign, return the modified class, else return the original class
+        return bytes;
+    }
+}

--- a/src/main/java/myessentials/entities/sign/SignManager.java
+++ b/src/main/java/myessentials/entities/sign/SignManager.java
@@ -1,6 +1,7 @@
 package myessentials.entities.sign;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import myessentials.classtransformers.SignClassTransformer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntitySign;

--- a/src/main/java/myessentials/entities/sign/SignManager.java
+++ b/src/main/java/myessentials/entities/sign/SignManager.java
@@ -1,9 +1,15 @@
 package myessentials.entities.sign;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
-import myessentials.entities.BlockPos;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntitySign;
+import net.minecraft.world.World;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.world.BlockEvent;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * If a sign is created, registering it here will route all the needed event interactions to it.
@@ -12,7 +18,23 @@ public class SignManager {
 
     public static final SignManager instance = new SignManager();
 
-    public final Sign.Container signs = new Sign.Container();
+    public final Map<String, SignType> signTypes = new HashMap<String, SignType>(1);
+
+    public Sign loadSign(World world, int x, int y, int z) {
+        TileEntity tileEntity = world.getTileEntity(x, y, z);
+        if(!(tileEntity instanceof TileEntitySign))
+            return null;
+
+        NBTTagCompound tagCompound = SignClassTransformer.getMyEssentialsDataValue(tileEntity);
+        if(tagCompound == null)
+            return null;
+
+        SignType signType = signTypes.get(tagCompound.getString("Type"));
+        if(signType == null)
+            return null;
+
+        return signType.loadData((TileEntitySign) tileEntity, tagCompound.getTag("Value"));
+    }
 
     @SubscribeEvent
     public void onPlayerInteract(PlayerInteractEvent ev) {
@@ -20,15 +42,9 @@ public class SignManager {
             return;
         }
 
-        Sign sign = signs.get(new BlockPos(ev.x, ev.y, ev.z, ev.world.provider.dimensionId));
-        if(sign == null) {
+        Sign sign = loadSign(ev.world, ev.x, ev.y, ev.z);
+        if(sign == null)
             return;
-        }
-
-        if(sign.getTileEntity() == null) {
-            signs.remove(sign);
-            return;
-        }
 
         if(ev.entityPlayer.isSneaking()) {
             sign.onShiftRightClick(ev.entityPlayer);
@@ -39,7 +55,7 @@ public class SignManager {
 
     @SubscribeEvent
     public void onPlayerBreaksBlock(BlockEvent.BreakEvent ev) {
-        Sign sign = signs.get(new BlockPos(ev.x, ev.y, ev.z, ev.world.provider.dimensionId));
+        Sign sign = loadSign(ev.world, ev.x, ev.y, ev.z);
 
         if(sign != null) {
             sign.onShiftRightClick(ev.getPlayer());

--- a/src/main/java/myessentials/entities/sign/SignType.java
+++ b/src/main/java/myessentials/entities/sign/SignType.java
@@ -1,0 +1,14 @@
+package myessentials.entities.sign;
+
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.tileentity.TileEntitySign;
+
+public abstract class SignType {
+    public abstract String getTypeID();
+
+    public abstract Sign loadData(TileEntitySign tileEntity, NBTBase signData);
+
+    public void register() {
+        SignManager.instance.signTypes.put(getTypeID(), this);
+    }
+}

--- a/src/main/java/myessentials/entities/sign/SignType.java
+++ b/src/main/java/myessentials/entities/sign/SignType.java
@@ -27,4 +27,6 @@ public abstract class SignType {
     public void register() {
         SignManager.instance.signTypes.put(getTypeID(), this);
     }
+
+    public abstract boolean isTileValid(TileEntitySign te);
 }

--- a/src/main/java/myessentials/entities/sign/SignType.java
+++ b/src/main/java/myessentials/entities/sign/SignType.java
@@ -3,11 +3,27 @@ package myessentials.entities.sign;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.tileentity.TileEntitySign;
 
+/**
+ * A type of a wrapped sign block on the server side.
+ */
 public abstract class SignType {
+    /**
+     * The unique ID for this type.
+     * @return The ID following the syntax: "modId:signType"
+     */
     public abstract String getTypeID();
 
+    /**
+     * Loads a sign data of this type.
+     * @param tileEntity The tile entity that is being loaded
+     * @param signData The data stored on the sign
+     * @return The loaded sign
+     */
     public abstract Sign loadData(TileEntitySign tileEntity, NBTBase signData);
 
+    /**
+     * Register this type on the {@link SignManager}, all types must be registered to be recognized.
+     */
     public void register() {
         SignManager.instance.signTypes.put(getTypeID(), this);
     }


### PR DESCRIPTION
These commits changes how MyEssentials-Core handles custom signs, they won't be stored on a map nor use the sign lines to store that, they will use NBT tags to store them.

The changes tot the sign api:
- The SignClassTransformer class will patch the TileEntitySign to allow it to hold, load and save any custom NBT data
- SignType represents any type of customizable sign, it can validate and load a Sign object based on the custom NBT tags. It must be registered on SignManager otherwise it won't load the custom signs.
- The Sign class now is a loaded state of a custom sign, it's created by the SignType when a sign of that type is activated and it must rely on NBT data instead of the sign lines, the lines are now to show information to the players

I also merged from the master to simplify the pull request, otherwise github wouldn't be able to merge it automatically.