### PR TITLE
Bug with getAllInterfaces

### DIFF
--- a/src/main/java/myessentials/utils/ClassUtils.java
+++ b/src/main/java/myessentials/utils/ClassUtils.java
@@ -4,7 +4,10 @@ import net.minecraft.server.MinecraftServer;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * All utilities exclusively for classes go here
@@ -31,16 +34,16 @@ public class ClassUtils {
         return MinecraftServer.getServer().getServerModName().contains("cauldron") || MinecraftServer.getServer().getServerModName().contains("mcpc");
     }
 
-    public static List<Class<?>> getAllInterfaces(Class<?> cls) {
-        List<Class<?>> lst = new ArrayList<Class<?>>();
-
-        lst.addAll(Arrays.asList(cls.getInterfaces()));
+    public static Collection<Class<?>> getAllInterfaces(Class<?> cls) {
+    	Set<Class<?>> interfaces = new HashSet<Class<?>>();
+    	
+    	interfaces.addAll(Arrays.asList(cls.getInterfaces()));
 
         Class<?> s = cls.getSuperclass();
         if (s != null) {
-            lst.addAll(getAllInterfaces(s));
+        	interfaces.addAll(getAllInterfaces(s));
         }
 
-        return lst;
+        return interfaces;
     }
 }

--- a/src/main/java/myessentials/utils/ClassUtils.java
+++ b/src/main/java/myessentials/utils/ClassUtils.java
@@ -2,11 +2,9 @@ package myessentials.utils;
 
 import net.minecraft.server.MinecraftServer;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 /**


### PR DESCRIPTION
Multiple Classes in a hierarchy can implement the same class. This is bad design on their part but this simple change prevents that from causing duplicates in the List returned. Also changed to Collection from List to respect Dependency Inversion Principle.
